### PR TITLE
remove dynamic propertiy definition 

### DIFF
--- a/edit/base.class.php
+++ b/edit/base.class.php
@@ -27,7 +27,7 @@ defined('MOODLE_INTERNAL') || die();
 class edit_base {
 
     public $imageobj;
-
+    public $cm;
     public $gallery;
     public $image;
     public $lbgimage;


### PR DESCRIPTION
PHP 8.2: Dynamic Properties are deprecated