### PR TITLE
Avoid tabObject not found error when editing image

### DIFF
--- a/imageedit.php
+++ b/imageedit.php
@@ -58,7 +58,7 @@ $tabs = array();
 foreach ($edittypes as $type => $name) {
     $editurl = new moodle_url('/mod/lightboxgallery/imageedit.php',
                                 array('id' => $cm->id, 'image' => $image, 'page' => $page, 'tab' => $type));
-    $tabs[] = new tabObject($type, $editurl, $name);
+    $tabs[] = new tabobject($type, $editurl, $name);
 }
 
 if (!in_array($tab, array_keys($edittypes))) {


### PR DESCRIPTION
When we try to edit an image, by clicking on one of the options in the drop-down box (Caption, Delete, Flip, etc.), we're getting the error:
Exception - Class "tabObject" not found
This change seems to fix it for us.